### PR TITLE
Handle Session State

### DIFF
--- a/config/production.js
+++ b/config/production.js
@@ -3,5 +3,7 @@ module.exports = {
   saltFile: '/etc/gluu/conf/salt',
   timerInterval: 60000,
   rateLimitWindowMs: 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
-  rateLimitMaxRequestAllow: 1000
+  rateLimitMaxRequestAllow: 1000,
+  cookieSameSite: 'none',
+  cookieSecure: true
 }

--- a/config/test.js
+++ b/config/test.js
@@ -182,6 +182,8 @@ const root = process.cwd()
 const passportFile = `${root}/test/testdata/passport-config.json`
 const rateLimitWindowMs = 24 * 60 * 60 * 1000
 const rateLimitMaxRequestAllow = 100
+const cookieSameSite = 'none'
+const cookieSecure = true
 
 module.exports = {
   saltFile,
@@ -190,5 +192,7 @@ module.exports = {
   rateLimitMaxRequestAllow,
   timerInterval,
   passportFile,
-  passportConfigAuthorizedResponse
+  passportConfigAuthorizedResponse,
+  cookieSameSite,
+  cookieSecure
 }

--- a/server/app-factory.js
+++ b/server/app-factory.js
@@ -1,7 +1,5 @@
 const express = require('express')
 const app = express()
-const session = require('express-session')
-const MemoryStore = require('memorystore')(session)
 const bodyParser = require('body-parser')
 const cookieParser = require('cookie-parser')
 const passport = require('passport')
@@ -9,10 +7,10 @@ const morgan = require('morgan')
 const logger = require('./utils/logging')
 const routes = require('./routes')
 const metricsMiddleware = require('../server/utils/metrics')
-const { randomSecret } = require('./utils/misc')
 const { globalErrorHandler } = require('./utils/error-handler')
 const flash = require('connect-flash')
 const { rateLimiter } = require('./utils/rate-limiter')
+const { session } = require('./utils/session')
 
 class AppFactory {
   createApp () {
@@ -24,19 +22,7 @@ class AppFactory {
     app.use(flash())
     app.use(rateLimiter)
     app.set('trust proxy', 1)
-    app.use(session({
-      cookie: {
-        maxAge: 86400000,
-        sameSite: 'none',
-        secure: true
-      },
-      store: new MemoryStore({
-        checkPeriod: 86400000 // prune expired entries every 24h
-      }),
-      secret: randomSecret(),
-      resave: false,
-      saveUninitialized: false
-    }))
+    app.use(session)
 
     app.use(passport.initialize())
     app.use(passport.session())

--- a/server/app-factory.js
+++ b/server/app-factory.js
@@ -23,10 +23,12 @@ class AppFactory {
     app.use(cookieParser())
     app.use(flash())
     app.use(rateLimiter)
-
+    app.set('trust proxy', 1)
     app.use(session({
       cookie: {
-        maxAge: 86400000
+        maxAge: 86400000,
+        sameSite: 'none',
+        secure: true
       },
       store: new MemoryStore({
         checkPeriod: 86400000 // prune expired entries every 24h

--- a/server/utils/session.js
+++ b/server/utils/session.js
@@ -1,0 +1,24 @@
+const expressSession = require('express-session')
+const MemoryStore = require('memorystore')(expressSession)
+const config = require('config')
+const { randomSecret } = require('../utils/misc')
+
+const expressSessionConfig = {
+  cookie: {
+    maxAge: 86400000,
+    sameSite: config.get('cookieSameSite'),
+    secure: config.get('cookieSecure')
+  },
+  store: new MemoryStore({
+    checkPeriod: 86400000 // prune expired entries every 24h
+  }),
+  secret: randomSecret(),
+  resave: false,
+  saveUninitialized: false
+}
+
+const session = expressSession(expressSessionConfig)
+
+module.exports = {
+  session
+}

--- a/test/app-factory.test.js
+++ b/test/app-factory.test.js
@@ -105,3 +105,26 @@ describe('rateLimiter middleware', () => {
     sinon.restore()
   })
 })
+
+describe('session middleware', () => {
+  const rewiredSession = appFactoryRewire.__get__('session')
+  const { session } = require('../server/utils/session')
+
+  it('should exist', () => {
+    assert.exists(rewiredSession)
+  })
+
+  it('should be a function', () => {
+    assert.isFunction(rewiredSession)
+  })
+
+  it('should be equal session middleware', () => {
+    assert.equal(rewiredSession, session)
+  })
+
+  it('should be called once as app.use arg', () => {
+    const appUseSpy = spyOnAppUse()
+    assertCalledWithFunctionAsArg(appUseSpy, rewiredSession)
+    sinon.restore()
+  })
+})

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1,0 +1,32 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
+const chai = require('chai')
+const assert = chai.assert
+const rewire = require('rewire')
+const sessionRewire = rewire('../server/utils/session')
+
+describe('rate-limiter.js test', () => {
+  const expressSessionConfig = sessionRewire.__get__('expressSessionConfig')
+  const session = sessionRewire.__get__('session')
+
+  it('expressSessionConfig should exist', () => {
+    assert.exists(expressSessionConfig)
+  })
+
+  it('expressSessionConfig should be object', () => {
+    assert.isObject(expressSessionConfig)
+  })
+
+  it('expressSessionConfig should have cookie.sameSite and cookie.secure', () => {
+    const cookie = expressSessionConfig.cookie
+    assert.exists(cookie.sameSite)
+    assert.exists(cookie.secure)
+  })
+
+  it('session should exist', () => {
+    assert.exists(session)
+  })
+
+  it('session should be function', () => {
+    assert.isFunction(session)
+  })
+})


### PR DESCRIPTION
Handle session state properly specially in Apple Auth case, When apple return to `/callback` endpoint with state, code and session, browser need `sameSite=none` so that browser can send same cookie again to `gluu-passport` instead of creating new cookie. If we not set `sameSite=none` then passport takes `apple request` as a new request and creates new session due to this `state` verification fails.

closes #242 