### PR TITLE
feat(httpProxy): add support to global http proxy

### DIFF
--- a/config/production.js
+++ b/config/production.js
@@ -8,5 +8,6 @@ module.exports = {
   rateLimitMaxRequestAllow: 1000,
   cookieSameSite: 'none',
   cookieSecure: true,
-  HTTP_PROXY: process.env.HTTP_PROXY
+  HTTP_PROXY: process.env.HTTP_PROXY,
+  NO_PROXY: process.env.NO_PROXY
 }

--- a/config/production.js
+++ b/config/production.js
@@ -1,5 +1,3 @@
-process.env.GLOBAL_AGENT_NO_PROXY = 'localhost,127.0.0.1' || process.env.no_proxy
-
 module.exports = {
   passportFile: '/etc/gluu/conf/passport-config.json',
   saltFile: '/etc/gluu/conf/salt',

--- a/config/production.js
+++ b/config/production.js
@@ -5,5 +5,6 @@ module.exports = {
   rateLimitWindowMs: 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
   rateLimitMaxRequestAllow: 1000,
   cookieSameSite: 'none',
-  cookieSecure: true
+  cookieSecure: true,
+  HTTP_PROXY: process.env.HTTP_PROXY
 }

--- a/config/production.js
+++ b/config/production.js
@@ -7,5 +7,6 @@ module.exports = {
   cookieSameSite: 'none',
   cookieSecure: true,
   HTTP_PROXY: process.env.HTTP_PROXY,
+  HTTPS_PROXY: process.env.HTTPS_PROXY,
   NO_PROXY: process.env.NO_PROXY
 }

--- a/config/production.js
+++ b/config/production.js
@@ -1,3 +1,5 @@
+process.env.GLOBAL_AGENT_NO_PROXY = 'localhost,127.0.0.1' || process.env.no_proxy
+
 module.exports = {
   passportFile: '/etc/gluu/conf/passport-config.json',
   saltFile: '/etc/gluu/conf/salt',

--- a/config/test.js
+++ b/config/test.js
@@ -239,6 +239,7 @@ const cookieSameSite = 'none'
 const cookieSecure = true
 
 const HTTP_PROXY = 'http://localhost:3128'
+const HTTPS_PROXY = 'http://localhost:3129'
 const NO_PROXY = 'localhost,127.0.0.1'
 
 module.exports = {
@@ -252,5 +253,6 @@ module.exports = {
   cookieSameSite,
   cookieSecure,
   HTTP_PROXY,
-  NO_PROXY
+  NO_PROXY,
+  HTTPS_PROXY
 }

--- a/config/test.js
+++ b/config/test.js
@@ -239,7 +239,7 @@ const cookieSameSite = 'none'
 const cookieSecure = true
 
 const HTTP_PROXY = 'http://localhost:3128'
-process.env.GLOBAL_AGENT_NO_PROXY = 'localhost,127.0.0.1'
+const NO_PROXY = 'localhost,127.0.0.1'
 
 module.exports = {
   saltFile,
@@ -251,5 +251,6 @@ module.exports = {
   passportConfigAuthorizedResponse,
   cookieSameSite,
   cookieSecure,
-  HTTP_PROXY
+  HTTP_PROXY,
+  NO_PROXY
 }

--- a/config/test.js
+++ b/config/test.js
@@ -239,6 +239,7 @@ const cookieSameSite = 'none'
 const cookieSecure = true
 
 const HTTP_PROXY = 'http://localhost:3128'
+process.env.GLOBAL_AGENT_NO_PROXY = 'localhost,127.0.0.1'
 
 module.exports = {
   saltFile,

--- a/config/test.js
+++ b/config/test.js
@@ -238,6 +238,8 @@ const rateLimitMaxRequestAllow = 100
 const cookieSameSite = 'none'
 const cookieSecure = true
 
+const HTTP_PROXY = 'http://localhost:3128'
+
 module.exports = {
   saltFile,
   passportConfig,
@@ -247,5 +249,6 @@ module.exports = {
   passportFile,
   passportConfigAuthorizedResponse,
   cookieSameSite,
-  cookieSecure
+  cookieSecure,
+  HTTP_PROXY
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express-prom-bundle": "^6.3.6",
         "express-rate-limit": "^5.2.3",
         "express-session": "^1.17.2",
+        "global-agent": "^3.0.0",
         "got": "^11.8.1",
         "jose": "^2.0.4",
         "jsonwebtoken": "^8.4.0",
@@ -1626,6 +1627,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2859,7 +2865,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -2923,6 +2928,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/did-you-mean": {
       "version": "0.0.1",
@@ -3209,8 +3219,7 @@
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
@@ -4975,6 +4984,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -5043,6 +5068,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/got": {
@@ -6184,8 +6223,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -6942,6 +6980,28 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8117,7 +8177,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9935,6 +9994,27 @@
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -9987,7 +10067,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10001,14 +10080,12 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10019,8 +10096,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.17.1",
@@ -10049,6 +10125,31 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -13032,6 +13133,11 @@
         "type-is": "~1.6.17"
       }
     },
+    "boolean": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -14012,7 +14118,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -14055,6 +14160,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "did-you-mean": {
       "version": "0.0.1",
@@ -14292,8 +14402,7 @@
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -15622,6 +15731,19 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      }
+    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -15674,6 +15796,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      }
+    },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "got": {
@@ -16517,8 +16647,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -17119,6 +17248,21 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
       "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
+    },
+    "matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -18012,8 +18156,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
@@ -19359,6 +19502,26 @@
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
+    "roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -19407,7 +19570,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -19416,7 +19578,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -19424,16 +19585,14 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "send": {
       "version": "0.17.1",
@@ -19459,6 +19618,21 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "requires": {
+        "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express-prom-bundle": "^6.3.6",
     "express-rate-limit": "^5.2.3",
     "express-session": "^1.17.2",
+    "global-agent": "^3.0.0",
     "got": "^11.8.1",
     "jose": "^2.0.4",
     "jsonwebtoken": "^8.4.0",

--- a/server/app-factory.js
+++ b/server/app-factory.js
@@ -11,6 +11,8 @@ const { globalErrorHandler } = require('./utils/error-handler')
 const flash = require('connect-flash')
 const { rateLimiter } = require('./utils/rate-limiter')
 const { session } = require('./utils/session')
+// Setup http proxy config
+require('./utils/http-global-proxy')
 
 class AppFactory {
   createApp () {

--- a/server/utils/http-global-proxy.js
+++ b/server/utils/http-global-proxy.js
@@ -4,5 +4,6 @@ if (config.has('HTTP_PROXY')) {
   const ga = require('global-agent')
   ga.bootstrap()
   global.GLOBAL_AGENT.HTTP_PROXY = config.get('HTTP_PROXY')
+  global.GLOBAL_AGENT.HTTPS_PROXY = config.get('HTTPS_PROXY')
   global.GLOBAL_AGENT.NO_PROXY = config.get('NO_PROXY')
 }

--- a/server/utils/http-global-proxy.js
+++ b/server/utils/http-global-proxy.js
@@ -1,0 +1,7 @@
+const config = require('config')
+
+if (config.has('HTTP_PROXY')) {
+  const ga = require('global-agent')
+  ga.bootstrap()
+  global.GLOBAL_AGENT.HTTP_PROXY = config.get('HTTP_PROXY')
+}

--- a/server/utils/http-global-proxy.js
+++ b/server/utils/http-global-proxy.js
@@ -4,4 +4,5 @@ if (config.has('HTTP_PROXY')) {
   const ga = require('global-agent')
   ga.bootstrap()
   global.GLOBAL_AGENT.HTTP_PROXY = config.get('HTTP_PROXY')
+  global.GLOBAL_AGENT.NO_PROXY = config.get('NO_PROXY')
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -37,7 +37,7 @@ const setupServer = async function () {
   await app.on('appStarted', () => {
     console.log('app started...')
   })
-  await app.rateLimiter.resetKey('127.0.0.1')
+  await app.rateLimiter.resetKey('::ffff:127.0.0.1')
   return chai.request(app).keepOpen()
 }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -37,7 +37,7 @@ const setupServer = async function () {
   await app.on('appStarted', () => {
     console.log('app started...')
   })
-  await app.rateLimiter.resetKey('::ffff:127.0.0.1')
+  await app.rateLimiter.resetKey('127.0.0.1')
   return chai.request(app).keepOpen()
 }
 

--- a/test/http-global-proxy.spec.js
+++ b/test/http-global-proxy.spec.js
@@ -1,0 +1,23 @@
+const chai = require('chai')
+const config = require('config')
+const http = require('http')
+
+const assert = chai.assert
+const HTTP_PROXY = config.get('HTTP_PROXY')
+
+describe('global agent proxy setup', () => {
+  it('node global object should have global agent and proxy setup', async () => {
+    assert.exists(global.GLOBAL_AGENT)
+    assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+  })
+
+  it('http object should have global agent and proxy setup', async () => {
+    assert.exists(http.globalAgent)
+    const proxySetting = http.globalAgent.getUrlProxy()
+    assert.exists(proxySetting)
+    const proxyURL = new URL(HTTP_PROXY)
+    assert.equal(proxySetting.hostname, proxyURL.hostname)
+    assert.equal(proxySetting.port, proxyURL.port)
+  })
+})

--- a/test/http-global-proxy.spec.js
+++ b/test/http-global-proxy.spec.js
@@ -1,9 +1,11 @@
 const chai = require('chai')
 const config = require('config')
 const http = require('http')
+const https = require('https')
 
 const assert = chai.assert
 const HTTP_PROXY = config.get('HTTP_PROXY')
+const HTTPS_PROXY = config.get('HTTPS_PROXY')
 const NO_PROXY = config.get('NO_PROXY')
 
 describe('global agent proxy setup', () => {
@@ -13,10 +15,12 @@ describe('global agent proxy setup', () => {
 
   it('global agent object should have http proxy settings', () => {
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+    assert.exists(global.GLOBAL_AGENT.HTTPS_PROXY)
   })
 
   it('global agent object config should match with app proxy configs', () => {
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.HTTPS_PROXY, HTTPS_PROXY)
     assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })
 
@@ -29,6 +33,18 @@ describe('global agent proxy setup', () => {
 
   it("http object's global agent proxy details should match with app proxy config", () => {
     const proxyURL = new URL(HTTP_PROXY)
+    assert.equal(proxySetting.hostname, proxyURL.hostname)
+    assert.equal(proxySetting.port, proxyURL.port)
+  })
+
+  it('https object should have global agent proxy details', async () => {
+    assert.exists(https.globalAgent)
+    proxySetting = https.globalAgent.getUrlProxy()
+    assert.exists(proxySetting)
+  })
+
+  it("https object's global agent proxy details should match with app proxy config", () => {
+    const proxyURL = new URL(HTTPS_PROXY)
     assert.equal(proxySetting.hostname, proxyURL.hostname)
     assert.equal(proxySetting.port, proxyURL.port)
   })

--- a/test/http-global-proxy.spec.js
+++ b/test/http-global-proxy.spec.js
@@ -7,18 +7,27 @@ const HTTP_PROXY = config.get('HTTP_PROXY')
 const NO_PROXY = config.get('NO_PROXY')
 
 describe('global agent proxy setup', () => {
-  it('node global object should have global agent and proxy setup', async () => {
+  it('global agent object should have global agent', async () => {
     assert.exists(global.GLOBAL_AGENT)
+  })
+
+  it('global agent object should have http proxy settings', () => {
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+  })
+
+  it('global agent object config should match with app proxy configs', () => {
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
     assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })
 
-  it('http object should have global agent and proxy setup', async () => {
+  let proxySetting = null
+  it('http object should have global agent proxy details', async () => {
     assert.exists(http.globalAgent)
-    const proxySetting = http.globalAgent.getUrlProxy()
-    console.log(proxySetting)
+    proxySetting = http.globalAgent.getUrlProxy()
     assert.exists(proxySetting)
+  })
+
+  it("http object's global agent proxy details should match with app proxy config", () => {
     const proxyURL = new URL(HTTP_PROXY)
     assert.equal(proxySetting.hostname, proxyURL.hostname)
     assert.equal(proxySetting.port, proxyURL.port)

--- a/test/http-global-proxy.spec.js
+++ b/test/http-global-proxy.spec.js
@@ -4,17 +4,20 @@ const http = require('http')
 
 const assert = chai.assert
 const HTTP_PROXY = config.get('HTTP_PROXY')
+const NO_PROXY = config.get('NO_PROXY')
 
 describe('global agent proxy setup', () => {
   it('node global object should have global agent and proxy setup', async () => {
     assert.exists(global.GLOBAL_AGENT)
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })
 
   it('http object should have global agent and proxy setup', async () => {
     assert.exists(http.globalAgent)
     const proxySetting = http.globalAgent.getUrlProxy()
+    console.log(proxySetting)
     assert.exists(proxySetting)
     const proxyURL = new URL(HTTP_PROXY)
     assert.equal(proxySetting.hostname, proxyURL.hostname)

--- a/test/http-global-proxy.test.js
+++ b/test/http-global-proxy.test.js
@@ -4,6 +4,7 @@ const rewire = require('rewire')
 
 const assert = chai.assert
 const HTTP_PROXY = config.get('HTTP_PROXY')
+const NO_PROXY = config.get('NO_PROXY')
 
 describe('global agent proxy setup', () => {
   before(() => {
@@ -19,5 +20,6 @@ describe('global agent proxy setup', () => {
     assert.exists(global.GLOBAL_AGENT)
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })
 })

--- a/test/http-global-proxy.test.js
+++ b/test/http-global-proxy.test.js
@@ -1,0 +1,23 @@
+const chai = require('chai')
+const config = require('config')
+const rewire = require('rewire')
+
+const assert = chai.assert
+const HTTP_PROXY = config.get('HTTP_PROXY')
+
+describe('global agent proxy setup', () => {
+  before(() => {
+    global.GLOBAL_AGENT = null
+  })
+
+  it('node global object should not have proxy config', async () => {
+    assert.notExists(global.GLOBAL_AGENT)
+  })
+
+  it('node global object should have global agent and proxy setup', async () => {
+    rewire('../server/utils/http-global-proxy')
+    assert.exists(global.GLOBAL_AGENT)
+    assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+  })
+})

--- a/test/http-global-proxy.test.js
+++ b/test/http-global-proxy.test.js
@@ -18,7 +18,13 @@ describe('global agent proxy setup', () => {
   it('node global object should have global agent and proxy setup', async () => {
     rewire('../server/utils/http-global-proxy')
     assert.exists(global.GLOBAL_AGENT)
+  })
+
+  it('global agent object should have http proxy settings', () => {
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+  })
+
+  it('global agent object config should match with app proxy configs', () => {
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
     assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })

--- a/test/http-global-proxy.test.js
+++ b/test/http-global-proxy.test.js
@@ -4,6 +4,7 @@ const rewire = require('rewire')
 
 const assert = chai.assert
 const HTTP_PROXY = config.get('HTTP_PROXY')
+const HTTPS_PROXY = config.get('HTTPS_PROXY')
 const NO_PROXY = config.get('NO_PROXY')
 
 describe('global agent proxy setup', () => {
@@ -22,10 +23,12 @@ describe('global agent proxy setup', () => {
 
   it('global agent object should have http proxy settings', () => {
     assert.exists(global.GLOBAL_AGENT.HTTP_PROXY)
+    assert.exists(global.GLOBAL_AGENT.HTTPS_PROXY)
   })
 
   it('global agent object config should match with app proxy configs', () => {
     assert.equal(global.GLOBAL_AGENT.HTTP_PROXY, HTTP_PROXY)
+    assert.equal(global.GLOBAL_AGENT.HTTPS_PROXY, HTTPS_PROXY)
     assert.equal(global.GLOBAL_AGENT.NO_PROXY, NO_PROXY)
   })
 })


### PR DESCRIPTION
add configuration and feature to use http proxy

close #331 


Currently, this configuration is not available in oxTrust. You need to export environment variables:

| Property | Description |
|----------|-------------|
| HTTP_PROXY | Sets HTTP proxy to use |
| HTTPS_PROXY | Sets a distinct proxy to use for HTTPS requests.|
| NO_PROXY | Specifies a pattern of URLs that should be excluded from proxying.|
