### PR TITLE
ci(workflow): remove unused scan

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,6 @@
 # After coverage report gets generated a vulnerability scan runs and submits a sarif report directly to Security section in GitHub.
 
-name: Test, Codecov and VulnerabilityScan
+name: Test, Codecov
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -45,17 +45,6 @@ jobs:
         npm run build --if-present
         npm test
         npm run cover
-
-    # Runs vulnerability scan.
-    - uses: anchore/scan-action@v2
-      id: scan
-      with:
-        path: "."
-        acs-report-enable: true
-    - name: upload Anchore scan SARIF report
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: results.sarif
 
     - name: Upload to codecov
       uses: codecov/codecov-action@v1.0.10


### PR DESCRIPTION
As we are using Snyk, we don't need anchore. Anchore brings pollution and it does not ignore dev-deps