### PR TITLE
build: change max node engines to `<=16`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "standard-version": "^9.3.1"
       },
       "engines": {
-        "node": ">=12.19.0 <=16.13.0"
+        "node": ">=12.19.0 <=16.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "standard-version": "^9.3.1"
       },
       "engines": {
-        "node": ">=12.19.0 <=16.15.0"
+        "node": ">=12.19.0 <=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "engines": {
-    "node": ">=12.19.0 <=16.15.0"
+    "node": ">=12.19.0 <=16"
   },
   "scripts": {
     "start": "NODE_ENV=production node server/app.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "engines": {
-    "node": ">=12.19.0 <=16.13.0"
+    "node": ">=12.19.0 <=16.15.0"
   },
   "scripts": {
     "start": "NODE_ENV=production node server/app.js",


### PR DESCRIPTION
As major and minor upgrades were being blocked, we now block only breaking changes.

close #449 