### PR TITLE
feat(production.js): rate limit config from env

### DIFF
--- a/config/production.js
+++ b/config/production.js
@@ -2,8 +2,8 @@ module.exports = {
   passportFile: '/etc/gluu/conf/passport-config.json',
   saltFile: '/etc/gluu/conf/salt',
   timerInterval: 60000,
-  rateLimitWindowMs: 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
-  rateLimitMaxRequestAllow: 1000,
+  rateLimitWindowMs: parseInt(process.env.PASSPORT_RATE_LIMIT_WINDOW_MS) || 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
+  rateLimitMaxRequestAllow: parseInt(process.env.PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW) || 1000,
   cookieSameSite: 'none',
   cookieSecure: true,
   HTTP_PROXY: process.env.HTTP_PROXY,

--- a/config/production.js
+++ b/config/production.js
@@ -2,8 +2,8 @@ module.exports = {
   passportFile: '/etc/gluu/conf/passport-config.json',
   saltFile: '/etc/gluu/conf/salt',
   timerInterval: 60000,
-  rateLimitWindowMs: parseInt(process.env.PASSPORT_RATE_LIMIT_WINDOW_MS) || 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
-  rateLimitMaxRequestAllow: parseInt(process.env.PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW) || 1000,
+  rateLimitWindowMs: parseInt(process.env.PASSPORT_RATE_LIMIT_WINDOW_MS, 10) || 24 * 60 * 60 * 1000, // 24 hrs in milliseconds
+  rateLimitMaxRequestAllow: parseInt(process.env.PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW, 10) || 1000,
   cookieSameSite: 'none',
   cookieSecure: true,
   HTTP_PROXY: process.env.HTTP_PROXY,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,6 +1,8 @@
 
 const chai = require('chai')
 const assert = chai.assert
+const rewire = require('rewire')
+const sinon = require('sinon')
 
 /**
  * Testing configs (env) on /config/*.js (uses node-config module)
@@ -34,7 +36,7 @@ describe('defaultcfg', function () {
 })
 
 describe('productioncfg', function () {
-  it('production.js should have passportFile  not null or undefined', () => {
+  it('production.js should have passportFile not null or undefined', () => {
     assert.exists(
       productioncfg.passportFile, 'passportFile is not null or undefined')
   })
@@ -55,5 +57,37 @@ describe('productioncfg', function () {
       productioncfg.cookieSecure, 'cookieSecure does NOT exist'
     )
     assert.isTrue(productioncfg.cookieSecure)
+  })
+  describe('rate limit', () => {
+    describe('limitWindowMs', () => {
+      it('should load from env', () => {
+        const rateLimitWindow = 1
+        process.env.PASSPORT_RATE_LIMIT_WINDOW_MS = rateLimitWindow
+        const rewiredProductionCfg = rewire('../config/production.js')
+        assert.equal(rewiredProductionCfg.rateLimitWindowMs, 1)
+      })
+      it('should call parseInt once with value', () => {
+        process.env.PASSPORT_RATE_LIMIT_WINDOW_MS = 'a valid rate limit'
+        const parseIntspy = sinon.spy(global, 'parseInt')
+        rewire('../config/production.js')
+        assert.isTrue(parseIntspy.calledWith('a valid rate limit'))
+        global.parseInt.restore()
+      })
+    })
+    describe('maxRequestAllow', () => {
+      it('should load from env', () => {
+        const maxRequestAllow = 2
+        process.env.PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW = maxRequestAllow
+        const rewiredProductionCfg = rewire('../config/production.js')
+        assert.equal(rewiredProductionCfg.rateLimitMaxRequestAllow, 2)
+      })
+      it('should call parseInt with value', () => {
+        process.env.PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW = 'a valid max request limit'
+        const parseIntspy = sinon.spy(global, 'parseInt')
+        rewire('../config/production.js')
+        assert.isTrue(parseIntspy.calledWith('a valid max request limit'))
+        global.parseInt.restore()
+      })
+    })
   })
 })


### PR DESCRIPTION
close #450 

In production environment, rate limit configurations are loaded from ENV variables: `PASSPORT_RATE_LIMIT_WINDOW_MS` and `PASSPORT_RATE_LIMIT_MAX_REQUEST_ALLOW`, if none,  default values are loaded.