### PR TITLE
ci: setup to merge to upcoming 4.4.1 branch

### DIFF
--- a/.github/workflows/branchmerger.yml
+++ b/.github/workflows/branchmerger.yml
@@ -13,5 +13,5 @@ jobs:
           with:
               type: now
               head_to_merge: ${{ github.ref }}
-              target_branch: version_4.4.0
+              target_branch: version_4.4.1
               github_token: ${{ github.token }}


### PR DESCRIPTION
It was mistakenly merging to 4.4.0

ps: using `ci` commit as is not a code fix.