### PR TITLE
fix(security): update passport twitter xmldom dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8648,7 +8648,7 @@
     },
     "node_modules/passport-twitter": {
       "version": "1.0.4",
-      "resolved": "git+ssh://git@github.com/GluuFederation/passport-twitter.git#4a9f357cf9b3c9fd20e42499ebca6b78e51ef68e",
+      "resolved": "git+ssh://git@github.com/GluuFederation/passport-twitter.git#9e1bb7a0987909e0bb84b265ab4d6f03ce9fd19c",
       "license": "MIT",
       "dependencies": {
         "passport-oauth1": "1.x.x",
@@ -11818,18 +11818,18 @@
     },
     "node_modules/xtraverse": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/GluuFederation/node-xtraverse.git#f1497025b67d7c46cd32af967714871a697899e1",
+      "resolved": "git+ssh://git@github.com/GluuFederation/node-xtraverse.git#bcf625bbd5fe0c533600d118b38eccf12caa3f5f",
       "dependencies": {
-        "@xmldom/xmldom": "0.7.1"
+        "@xmldom/xmldom": "0.8.6"
       },
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/xtraverse/node_modules/@xmldom/xmldom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.1.tgz",
-      "integrity": "sha512-EOzJBMOjJ657nmlTt5RsyEwJrMTMu0aX15pI96GmpyFPj33a9J4mkcEk0KqYGplqInQ6JsPUxv/R25jR+I5ADA==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -18553,7 +18553,7 @@
       }
     },
     "passport-twitter": {
-      "version": "git+ssh://git@github.com/GluuFederation/passport-twitter.git#4a9f357cf9b3c9fd20e42499ebca6b78e51ef68e",
+      "version": "git+ssh://git@github.com/GluuFederation/passport-twitter.git#9e1bb7a0987909e0bb84b265ab4d6f03ce9fd19c",
       "from": "passport-twitter@git+https://github.com/GluuFederation/passport-twitter.git",
       "requires": {
         "passport-oauth1": "1.x.x",
@@ -21017,16 +21017,16 @@
       "dev": true
     },
     "xtraverse": {
-      "version": "git+ssh://git@github.com/GluuFederation/node-xtraverse.git#f1497025b67d7c46cd32af967714871a697899e1",
+      "version": "git+ssh://git@github.com/GluuFederation/node-xtraverse.git#bcf625bbd5fe0c533600d118b38eccf12caa3f5f",
       "from": "xtraverse@git+https://github.com/GluuFederation/node-xtraverse.git",
       "requires": {
-        "@xmldom/xmldom": "0.7.1"
+        "@xmldom/xmldom": "0.8.6"
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.1.tgz",
-          "integrity": "sha512-EOzJBMOjJ657nmlTt5RsyEwJrMTMu0aX15pI96GmpyFPj33a9J4mkcEk0KqYGplqInQ6JsPUxv/R25jR+I5ADA=="
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+          "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
         }
       }
     },


### PR DESCRIPTION
Update Gluu's fork of passport-twitter version.

Updated `xmldom` in `GluuFederation/node-xtraverse`, updated `node-xtraverse` in `GluuFederation/passport-twitter`, updated `passport-twitter` in `GluuFederation/gluu-passport`
