### PR TITLE
fix(openid-client): pass provided scope in auth request

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -99,6 +99,10 @@ function validateProvider (req, res, next) {
 
   if (providerConfData) {
     // Attach some info for later use
+    if (providerConfData.type === 'openid-client') {
+      const scope = providerConfData.options.scope
+      providerConfData.passportAuthnParams.scope = scope && scope.length > 1 && scope.join(' ')
+    }
     req.passportAuthenticateParams = providerConfData.passportAuthnParams
     next()
   } else {


### PR DESCRIPTION
PR Contains: openid-client lib not really taking its client object scope so need to pass it from config